### PR TITLE
Added a spec and a change in EvaluationEmailer to account for a template

### DIFF
--- a/app/models/evaluation_emailer.rb
+++ b/app/models/evaluation_emailer.rb
@@ -52,9 +52,13 @@ class EvaluationEmailer
   def self.remind_peers_reminder(participant)
     training = participant.training
     template_name = "reminder-to-remind-#{training.questionnaire.name}"
+    if template_name == "reminder-to-remind-Public-ProgramsFellowship"
+       return
+    else
     message = participant_message(participant)
     message["subject"] = "Rockwood: 360 Leadership Assessment Reminder"
     send_template(template_name, message)
+    end
   end
 
 
@@ -102,9 +106,6 @@ class EvaluationEmailer
     end
 
     def self.send_template(template_name, message)
-      if template_name == 'Public-ProgramsFellowship'
-        return
-      else
       results = mandrill.messages.send_template(template_name, [], message, true)
       sent_count = 0
       results.each do |result|
@@ -115,7 +116,6 @@ class EvaluationEmailer
         end
       end
       return sent_count
-    end
     end
 
     def self.mandrill

--- a/spec/models/evaluation_emailer_spec.rb
+++ b/spec/models/evaluation_emailer_spec.rb
@@ -43,6 +43,14 @@ describe EvaluationEmailer do
     end
   end
 
+  describe '.remind_peers_reminder' do
+    it 'does not send reminder-to-remind-PublicProgramsFellowship' do
+      expect(EvaluationEmailer).not_to receive(:send_template).
+        with("reminder-to-remind-PublicProgramsFellowship", anything())
+      EvaluationEmailer.remind_peers_reminder(@participant)
+    end
+  end
+
   describe '.send_peer_invites' do
     context 'when it successfully sends' do
       it 'returns a count for number of messages sent' do


### PR DESCRIPTION
'PublicPrograms-Fellowship' to not be sent out. Hoping that this fixes the Mandrill error.